### PR TITLE
Literal values should be quoted in Python.ts

### DIFF
--- a/packages/quicktype-core/src/language/Python.ts
+++ b/packages/quicktype-core/src/language/Python.ts
@@ -475,7 +475,7 @@ export class PythonRenderer extends ConvenienceRenderer {
         // Custom to HF fork: emit as Literal instead of Enum
         this.emitLine([
             this.nameForNamedType(t),
-            this.typeHint(" = ", this.withTyping("Literal"), "[", arrayIntercalate(", ", Array.from(t.cases.keys())), "]")
+            this.typeHint(" = ", this.withTyping("Literal"), "[", arrayIntercalate(", ", Array.from(t.cases.keys()).map(this.string)), "]")
         ]);
     }
 


### PR DESCRIPTION
cc @SBrandeis 

Result example:

```py
ClassificationOutputTransform = Literal["sigmoid", "softmax", "none"]
```